### PR TITLE
Add issue template for releases

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -1,0 +1,41 @@
+---
+name: Release checklist
+about: 'Maintainers only: Checklist for making a new release'
+title: 'Release vX.Y.Z'
+labels: 'maintenance'
+assignees: ''
+
+---
+Checklist:
+
+- [x] Reserve a DOI on Zenodo and save the entry (fill required information first).
+- [x] Update the DOI in the README
+- [x] Update the release number, file size, and checksums in the README
+- [x] Update the list of changes in the README
+- [x] Fill out the Zenodo metadata and description following the example other Fatiando Data publications and latest changes from the README
+- [x] Create a new release (use the template below). The release name should be the version number with a leading `v` (e.g. `v1`).
+- [x] Upload the new data file to the release
+- [x] Publish the release
+- [x] Upload the new data file to Zenodo
+- [x] Publish the Zenodo archive
+
+GitHub release template:
+
+```markdown
+**Date:** YYYY/MM/DD
+
+**DOI:** https://doi.org/XXXX
+
+**Note:** This is a processed and formatted version of the source dataset below. It's mean for use in documentation and tutorials of the Fatiando a Terra project. Please cite the original authors when using this dataset.
+
+**Data source:** [The reference](Link to the reference, preferably a DOI)
+
+**Changes:**
+
+* List of changes made to the data
+
+| | Checksums |
+|--:|:--|
+| MD5 | `md5:XXX` |
+| SHA256 | `sha256:XXX` |
+```

--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -8,16 +8,16 @@ assignees: ''
 ---
 Checklist:
 
-- [x] Reserve a DOI on Zenodo and save the entry (fill required information first).
-- [x] Update the DOI in the README
-- [x] Update the release number, file size, and checksums in the README
-- [x] Update the list of changes in the README
-- [x] Fill out the Zenodo metadata and description following the example other Fatiando Data publications and latest changes from the README
-- [x] Create a new release (use the template below). The release name should be the version number with a leading `v` (e.g. `v1`).
-- [x] Upload the new data file to the release
-- [x] Publish the release
-- [x] Upload the new data file to Zenodo
-- [x] Publish the Zenodo archive
+- [ ] Reserve a DOI on Zenodo and save the entry (fill required information first).
+- [ ] Update the DOI in the README
+- [ ] Update the release number, file size, and checksums in the README
+- [ ] Update the list of changes in the README
+- [ ] Fill out the Zenodo metadata and description following the example other Fatiando Data publications and latest changes from the README
+- [ ] Create a new release (use the template below). The release name should be the version number with a leading `v` (e.g. `v1`).
+- [ ] Upload the new data file to the release
+- [ ] Publish the release
+- [ ] Upload the new data file to Zenodo
+- [ ] Publish the Zenodo archive
 
 GitHub release template:
 


### PR DESCRIPTION
Adds a checklist for making releases on dataset repos of fatiando-data.
The checklist is based on the one written down in https://github.com/fatiando-data/southern-africa-topography/issues/2

Fixes #5 