### PR TITLE
Change title of release issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -1,7 +1,7 @@
 ---
 name: Release checklist
 about: 'Maintainers only: Checklist for making a new release'
-title: 'Release vX.Y.Z'
+title: 'Release vX'
 labels: 'maintenance'
 assignees: ''
 


### PR DESCRIPTION
Each release issue should be named "Release vX" instead of using
semantic versioning (vX.Y.Z) for fatiando-data repositories.